### PR TITLE
Fix two bugs related to the console

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -91,8 +91,19 @@ namespace fwod
                 }
             }
 
-            //Console.Clear();
+            Console.Clear();
             Console.Title = ProjectName + " " + ProjectVersion;
+
+            /* Try to resize the console */
+            try
+            {
+                    Console.SetWindowSize(ConsoleTools.BufferWidth, ConsoleTools.BufferHeight);
+            }
+            catch(NotImplementedException)
+            {
+                    /* Mono sometimes throws an exception if it cannot change the window size */
+                    /* If so, keep going. */
+            }
 
             Game.EnemyList.Add(new Player());
 


### PR DESCRIPTION
If the console is not cleared on start it will most likely crash if
there is any content on the console.

If the console is too small, it will crash too. We can safely try a
resize.
